### PR TITLE
Added attribute readers for rows and columns size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 vendor/bundle
 .DS_Store
+.*.swp

--- a/lib/rusk.rb
+++ b/lib/rusk.rb
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-require "rusk/version"
+require File.expand_path('rusk/version', File.dirname(__FILE__))
 require 'nokogiri'
 require File.expand_path('rusk/book', File.dirname(__FILE__))
 require File.expand_path('rusk/sheet', File.dirname(__FILE__))
 require File.expand_path('rusk/cell', File.dirname(__FILE__))
+require File.expand_path('rusk/row', File.dirname(__FILE__))
 
 module Rusk
   # Your code goes here...

--- a/lib/rusk/row.rb
+++ b/lib/rusk/row.rb
@@ -1,16 +1,16 @@
 module Rusk
-	class Row
-		include Enumerable
+  class Row
+    include Enumerable
 
-		attr_reader :from
-		attr_reader :to
+    attr_reader :from
+    attr_reader :to
 
-		def initialize(from, to, content)
-			@from = from
-			@to = to
-			@content = content
-			@cells = []
-			@content.xpath('.//table:table-cell|.//table:covered-table-cell').each_with_index do |cell, index|
+    def initialize(from, to, content)
+      @from = from
+      @to = to
+      @content = content
+      @cells = []
+      @content.xpath('.//table:table-cell|.//table:covered-table-cell').each_with_index do |cell, index|
         number_repeated = cell["table:number-columns-repeated"].to_i
         break if number_repeated + index >= 1024
 
@@ -22,22 +22,22 @@ module Rusk
             @cells << Rusk::Cell.new(cell)
           end
         end
-			end
-		end
+      end
+    end
 
-		def [](column)
-			if column < @cells.size
-				@cells[column]
-			else
-				nil
-			end
-		end
+    def [](column)
+      if column < @cells.size
+        @cells[column]
+      else
+        nil
+      end
+    end
 
-		def each
-			@cells.each do |c|
-				yield c
-			end
-		end
+    def each
+      @cells.each do |c|
+        yield c
+      end
+    end
 
-	end
+  end
 end

--- a/lib/rusk/row.rb
+++ b/lib/rusk/row.rb
@@ -1,0 +1,43 @@
+module Rusk
+	class Row
+		include Enumerable
+
+		attr_reader :from
+		attr_reader :to
+
+		def initialize(from, to, content)
+			@from = from
+			@to = to
+			@content = content
+			@cells = []
+			@content.xpath('.//table:table-cell|.//table:covered-table-cell').each_with_index do |cell, index|
+        number_repeated = cell["table:number-columns-repeated"].to_i
+        break if number_repeated + index >= 1024
+
+        @cells << Rusk::Cell.new(cell)
+
+        if number_repeated > 1
+          cell.remove_attribute("number-columns-repeated")
+          (number_repeated - 1).times do
+            @cells << Rusk::Cell.new(cell)
+          end
+        end
+			end
+		end
+
+		def [](column)
+			if column < @cells.size
+				@cells[column]
+			else
+				nil
+			end
+		end
+
+		def each
+			@cells.each do |c|
+				yield c
+			end
+		end
+
+	end
+end

--- a/lib/rusk/sheet.rb
+++ b/lib/rusk/sheet.rb
@@ -4,6 +4,9 @@ module Rusk
   class Sheet
     include Enumerable
 
+		attr_reader :row_size
+		attr_reader :column_size
+
     def initialize(content)
       @content = content
       @cells = []

--- a/lib/rusk/sheet.rb
+++ b/lib/rusk/sheet.rb
@@ -4,8 +4,8 @@ module Rusk
   class Sheet
     include Enumerable
 
-		attr_reader :row_size
-		attr_reader :column_size
+    attr_reader :row_size
+    attr_reader :column_size
 
     def initialize(content)
       @content = content


### PR DESCRIPTION
When iterating through the rows in a sheet, it would be nice to know the position relative to the row count, e.g. when you need to ignore the last row in a sheet. Columns size added as a convenience, too.
